### PR TITLE
[Fix] Preserve system role in Responses Harmony parser

### DIFF
--- a/python/sglang/srt/entrypoints/harmony_utils.py
+++ b/python/sglang/srt/entrypoints/harmony_utils.py
@@ -128,18 +128,10 @@ def parse_response_input(
     if "type" not in response_msg or response_msg["type"] == "message":
         role = response_msg["role"]
         content = response_msg["content"]
-        if role == "system":
-            # User is trying to set a system message. Change it to:
-            # <|start|>developer<|message|># Instructions
-            # {instructions}<|end|>
-            role = "developer"
-            text_prefix = "Instructions:\n"
-        else:
-            text_prefix = ""
         if isinstance(content, str):
-            msg = Message.from_role_and_content(role, text_prefix + content)
+            msg = Message.from_role_and_content(role, content)
         else:
-            contents = [TextContent(text=text_prefix + c["text"]) for c in content]
+            contents = [TextContent(text=c["text"]) for c in content]
             msg = Message.from_role_and_contents(role, contents)
     elif response_msg["type"] == "function_call_output":
         call_id = response_msg["call_id"]

--- a/test/srt/openai_server/features/test_responses_system_role.py
+++ b/test/srt/openai_server/features/test_responses_system_role.py
@@ -1,0 +1,28 @@
+import unittest
+
+from sglang.srt.entrypoints.harmony_utils import parse_response_input
+
+
+class ResponsesSystemRoleTest(unittest.TestCase):
+    def test_system_role_message_is_preserved(self) -> None:
+        parsed = parse_response_input(
+            {"role": "system", "content": "Stay in character."},
+            prev_responses=[],
+        )
+        self.assertEqual(parsed.author.role, "system")
+        self.assertEqual(parsed.content[0].text, "Stay in character.")
+
+    def test_system_role_content_list_preserves_text(self) -> None:
+        parsed = parse_response_input(
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "Guidance"}],
+            },
+            prev_responses=[],
+        )
+        self.assertEqual(parsed.author.role, "system")
+        self.assertEqual(parsed.content[0].text, "Guidance")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -48,6 +48,7 @@ suites = {
         TestFile("openai_server/features/test_openai_server_ebnf.py", 95),
         TestFile("openai_server/features/test_openai_server_hidden_states.py", 240),
         TestFile("openai_server/features/test_reasoning_content.py", 89),
+        TestFile("openai_server/features/test_responses_system_role.py", 5),
         TestFile("openai_server/function_call/test_openai_function_calling.py", 60),
         TestFile("openai_server/function_call/test_tool_choice.py", 226),
         TestFile("openai_server/validation/test_large_max_new_tokens.py", 41),


### PR DESCRIPTION
## Motivation
- Fixes #11004 by keeping caller-supplied system messages in the system channel when building Harmony prompts for the Responses API.

## Modifications
- Preserve the original role/content in `parse_response_input` instead of coercing `system` messages into developer instructions.
- Add regression test `test_responses_system_role` and register it in the per-commit suite.

## Accuracy Tests
- N/A (no model-side kernel or numerics touched).

## Benchmarking and Profiling
- N/A (code only touches request preprocessing and unit tests).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
